### PR TITLE
Neil/missing hashes

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -66,8 +66,8 @@ package bitvec
 source-repository-package
     type: git
     location: https://github.com/CardanoSolutions/ouroboros-consensus
-    tag: 79da9a368cb6d2e7ed5ff5e89bb318b94c3c606d
-    --sha256: 02wjbvgbfdr5rybncxgx6slxh4gzx1vh4i34n6h834qghiq4yykb
+    tag: b56731a6305ba9bf7d858716f64098fec97490fc
+    --sha256: 05hv6j1hbxbdajzgv2l8m5p8bvva3nqiapy4mwm1qy8qzmz1d6g4
     subdir:
       ouroboros-consensus
       ouroboros-consensus-cardano

--- a/cardano-node/src/Cardano/Node/LedgerEvent.hs
+++ b/cardano-node/src/Cardano/Node/LedgerEvent.hs
@@ -25,7 +25,9 @@ module Cardano.Node.LedgerEvent (
   , LedgerNewEpochEvent (..)
   , LedgerRewardUpdateEvent (..)
   , Versioned (..)
+  , deserializeVersioned
   , ledgerEventName
+  , serializeVersioned
 
     -- ** Using Ledger events
   , StandardLedgerEventHandler
@@ -732,6 +734,7 @@ instance DecCBOR AnchoredEvents where
       <! From
 
 data Versioned a = Versioned Version a
+  deriving (Eq, Ord, Show)
 
 serializeVersioned :: EncCBOR a => Versioned a -> ByteString
 serializeVersioned (Versioned version x) =

--- a/cardano-node/test/Test/Cardano/Node/LedgerEvent.hs
+++ b/cardano-node/test/Test/Cardano/Node/LedgerEvent.hs
@@ -82,7 +82,7 @@ genAnchoredEvents =
     <*> genBlockHeaderHash
     <*> genSlotNo
     <*> genBlockNo
-    <*> Gen.nonEmpty
+    <*> Gen.list
           (Range.linear 0 20)
           (Gen.choice
             (mconcat


### PR DESCRIPTION
# Description

Allow `ledgerEvents` to be an empty list in `AnchoredEvents`
    
This allows us to keep track of the hashes of blocks that don't generate any ledger events

This is already being used in `marconi-sidechain-node` and is being tested there